### PR TITLE
Remove service workers

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -33,6 +33,7 @@ const config: GatsbyConfig = {
         icon: 'src/images/favicon.png',
       },
     },
+    'gatsby-plugin-remove-serviceworker',
   ],
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "gatsby-plugin-fix-fouc": "^1.1.2",
         "gatsby-plugin-image": "^3.14.0",
         "gatsby-plugin-manifest": "^5.14.0",
+        "gatsby-plugin-remove-serviceworker": "^1.0.0",
         "gatsby-plugin-sass": "^6.14.0",
         "gatsby-plugin-sharp": "^5.14.0",
         "gatsby-source-filesystem": "^5.14.0",
@@ -10451,6 +10452,12 @@
       "peerDependencies": {
         "gatsby": "^5.0.0-next"
       }
+    },
+    "node_modules/gatsby-plugin-remove-serviceworker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-remove-serviceworker/-/gatsby-plugin-remove-serviceworker-1.0.0.tgz",
+      "integrity": "sha512-8uQ/6PiM718BTZAgmQeEO6ULrJgLugmDVAkUGv5xxF0luBNrbboDgpsG0z1fbsotSDTzLWyULR0zzGNfWZaY7w==",
+      "license": "MIT"
     },
     "node_modules/gatsby-plugin-sass": {
       "version": "6.14.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "gatsby-plugin-fix-fouc": "^1.1.2",
     "gatsby-plugin-image": "^3.14.0",
     "gatsby-plugin-manifest": "^5.14.0",
+    "gatsby-plugin-remove-serviceworker": "^1.0.0",
     "gatsby-plugin-sass": "^6.14.0",
     "gatsby-plugin-sharp": "^5.14.0",
     "gatsby-source-filesystem": "^5.14.0",


### PR DESCRIPTION
They were still around from the `gatsby-plugin-offline`.
This caused the site to not display at all, when visited before the offline plugin was installed.